### PR TITLE
Rejuvenate log levels

### DIFF
--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -236,7 +236,7 @@ public class CLI {
             mode = Mode.HTTP;
         }
 
-        LOGGER.log(FINE, "using connection mode {0}", mode);
+        LOGGER.log(FINEST, "using connection mode {0}", mode);
 
         if (user != null && auth != null) {
             LOGGER.warning("-user and -auth are mutually exclusive");

--- a/core/src/main/java/hudson/DNSMultiCast.java
+++ b/core/src/main/java/hudson/DNSMultiCast.java
@@ -158,7 +158,7 @@ public class DNSMultiCast implements Closeable {
 //                this.waitForCanceled(DNSConstants.CLOSE_TIMEOUT);
 
                 // Stop the canceler timer
-                logger.finer("Canceling the state timer");
+                logger.finest("Canceling the state timer");
                 this.cancelStateTimer();
 
                 // Stop the executor

--- a/core/src/main/java/hudson/ExtensionList.java
+++ b/core/src/main/java/hudson/ExtensionList.java
@@ -373,7 +373,7 @@ public class ExtensionList<T> extends AbstractList<T> implements OnMaster {
      * Loads all the extensions.
      */
     protected List<ExtensionComponent<T>> load() {
-        LOGGER.fine(() -> String.format("Loading ExtensionList '%s'", extensionType.getName()));
+        LOGGER.finest(() -> String.format("Loading ExtensionList '%s'", extensionType.getName()));
         if (LOGGER.isLoggable(Level.FINER)) {
             LOGGER.log(Level.FINER, String.format("Loading ExtensionList '%s' from", extensionType.getName()), new Throwable("Only present for stacktrace information"));
         }

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -610,11 +610,11 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             LOGGER.fine(() -> "not considering loading a detached dependency " + shortName + " as it is already on disk");
             return;
         }
-        LOGGER.fine(() -> "considering loading a detached dependency " + shortName);
+        LOGGER.finer(() -> "considering loading a detached dependency " + shortName);
         for (String loadedFile : loadPluginsFromWar("/WEB-INF/detached-plugins", (dir, name) -> normalisePluginName(name).equals(shortName))) {
             String loaded = normalisePluginName(loadedFile);
             File arc = new File(rootDir, loaded + ".jpi");
-            LOGGER.info(() -> "Loading a detached plugin as a dependency: " + arc);
+            LOGGER.finer(() -> "Loading a detached plugin as a dependency: " + arc);
             try {
                 plugins.add(strategy.createPluginWrapper(arc));
             } catch (IOException e) {
@@ -783,7 +783,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                 }
             });
 
-            LOGGER.log(INFO, "Upgraded Jenkins from version {0} to version {1}. Loaded detached plugins (and dependencies): {2}",
+            LOGGER.log(FINEST, "Upgraded Jenkins from version {0} to version {1}. Loaded detached plugins (and dependencies): {2}",
                     new Object[] {lastExecVersion, Jenkins.VERSION, loadedDetached});
 
             InstallUtil.saveLastExecVersion();
@@ -813,7 +813,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                         return false;
                     }
                 });
-                LOGGER.log(INFO, "Upgraded detached plugins (and dependencies): {0}",
+                LOGGER.log(FINEST, "Upgraded detached plugins (and dependencies): {0}",
                         new Object[]{loadedDetached});
             }
         }
@@ -882,7 +882,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     @Restricted(NoExternalUse.class)
     public void dynamicLoad(File arc, boolean removeExisting, @CheckForNull List<PluginWrapper> batch) throws IOException, InterruptedException, RestartRequiredException {
         try (ACLContext context = ACL.as(ACL.SYSTEM)) {
-            LOGGER.log(FINE, "Attempting to dynamic load {0}", arc);
+            LOGGER.log(FINEST, "Attempting to dynamic load {0}", arc);
             PluginWrapper p = null;
             String sn;
             try {
@@ -1050,7 +1050,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
      * @param fileName like {@code abc.jpi}
      */
     protected void copyBundledPlugin(URL src, String fileName) throws IOException {
-        LOGGER.log(FINE, "Copying {0}", src);
+        LOGGER.log(FINER, "Copying {0}", src);
         fileName = fileName.replace(".hpi",".jpi"); // normalize fileNames to have the correct suffix
         String legacyName = fileName.replace(".jpi",".hpi");
         long lastModified = getModificationDate(src);

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -421,17 +421,17 @@ public final class TcpSlaveAgentListener extends Thread {
 
         public boolean connect(Socket socket) throws IOException {
             try {
-                LOGGER.log(Level.FINE, "Requesting ping from {0}", socket.getRemoteSocketAddress());
+                LOGGER.log(Level.FINEST, "Requesting ping from {0}", socket.getRemoteSocketAddress());
                 try (DataOutputStream out = new DataOutputStream(socket.getOutputStream())) {
                     out.writeUTF("Protocol:Ping");
                     try (InputStream in = socket.getInputStream()) {
                         byte[] response = new byte[ping.length];
                         int responseLength = in.read(response);
                         if (responseLength == ping.length && Arrays.equals(response, ping)) {
-                            LOGGER.log(Level.FINE, "Received ping response from {0}", socket.getRemoteSocketAddress());
+                            LOGGER.log(Level.FINEST, "Received ping response from {0}", socket.getRemoteSocketAddress());
                             return true;
                         } else {
-                            LOGGER.log(Level.FINE, "Expected ping response from {0} of {1} got {2}", new Object[]{
+                            LOGGER.log(Level.FINEST, "Expected ping response from {0} of {1} got {2}", new Object[]{
                                     socket.getRemoteSocketAddress(),
                                     new String(ping, StandardCharsets.UTF_8),
                                     responseLength > 0 && responseLength <= response.length ?

--- a/core/src/main/java/hudson/WebAppMain.java
+++ b/core/src/main/java/hudson/WebAppMain.java
@@ -130,7 +130,7 @@ public class WebAppMain implements ServletContextListener {
             final FileAndDescription describedHomeDir = getHomeDir(event);
             home = describedHomeDir.file.getAbsoluteFile();
             home.mkdirs();
-            LOGGER.info("Jenkins home directory: "+ home +" found at: " + describedHomeDir.description);
+            LOGGER.finest("Jenkins home directory: "+ home +" found at: " + describedHomeDir.description);
 
             // check that home exists (as mkdirs could have failed silently), otherwise throw a meaningful error
             if (!home.exists())

--- a/core/src/main/java/hudson/cli/CLICommand.java
+++ b/core/src/main/java/hudson/cli/CLICommand.java
@@ -246,10 +246,10 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
             p.parseArgument(args.toArray(new String[0]));
             if (!(this instanceof HelpCommand || this instanceof WhoAmICommand))
                 Jenkins.getActiveInstance().checkPermission(Jenkins.READ);
-            LOGGER.log(Level.FINE, "Invoking CLI command {0}, with {1} arguments, as user {2}.",
+            LOGGER.log(Level.FINEST, "Invoking CLI command {0}, with {1} arguments, as user {2}.",
                     new Object[] {getName(), args.size(), auth.getName()});
             int res = run();
-            LOGGER.log(Level.FINE, "Executed CLI command {0}, with {1} arguments, as user {2}, return code {3}",
+            LOGGER.log(Level.FINEST, "Executed CLI command {0}, with {1} arguments, as user {2}, return code {3}",
                     new Object[] {getName(), args.size(), auth.getName(), res});
             return res;
         } catch (CmdLineException e) {

--- a/core/src/main/java/hudson/cli/declarative/CLIRegisterer.java
+++ b/core/src/main/java/hudson/cli/declarative/CLIRegisterer.java
@@ -98,7 +98,7 @@ public class CLIRegisterer extends ExtensionFinder {
     }
 
     private List<ExtensionComponent<CLICommand>> discover(@Nonnull final Jenkins jenkins) {
-        LOGGER.fine("Listing up @CLIMethod");
+        LOGGER.finest("Listing up @CLIMethod");
         List<ExtensionComponent<CLICommand>> r = new ArrayList<>();
 
         try {

--- a/core/src/main/java/hudson/diagnosis/HudsonHomeDiskUsageChecker.java
+++ b/core/src/main/java/hudson/diagnosis/HudsonHomeDiskUsageChecker.java
@@ -52,7 +52,7 @@ public class HudsonHomeDiskUsageChecker extends PeriodicWork {
                 return;
             }
 
-            LOGGER.fine("Monitoring disk usage of JENKINS_HOME. total="+total+" free="+free);
+            LOGGER.finest("Monitoring disk usage of JENKINS_HOME. total="+total+" free="+free);
 
 
             // if it's more than 90% full and less than the minimum, activate

--- a/core/src/main/java/hudson/diagnosis/ReverseProxySetupMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/ReverseProxySetupMonitor.java
@@ -67,7 +67,7 @@ public class ReverseProxySetupMonitor extends AdministrativeMonitor {
         Jenkins j = Jenkins.get();
         // May need to send an absolute URL, since handling of HttpRedirect with a relative URL does not currently honor X-Forwarded-Proto/Port at all.
         String redirect = j.getRootUrl() + "administrativeMonitor/" + id + "/testForReverseProxySetup/" + (referer != null ? Util.rawEncode(referer) : "NO-REFERER") + "/";
-        LOGGER.log(Level.FINE, "coming from {0} and redirecting to {1}", new Object[] {referer, redirect});
+        LOGGER.log(Level.FINEST, "coming from {0} and redirecting to {1}", new Object[] {referer, redirect});
         return new HttpRedirect(redirect);
     }
 

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1380,7 +1380,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
 
         } else {
             // polling without workspace
-            LOGGER.fine("Polling SCM changes of " + getName());
+            LOGGER.finest("Polling SCM changes of " + getName());
             if (pollingBaseline==null) // see NOTE-NO-BASELINE above
                 calcPollingBaseline(getLastBuild(),null,listener);
             PollingResult r = scm.poll(this, null, null, listener, pollingBaseline);

--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -413,7 +413,7 @@ public class Executor extends Thread implements ModelObject {
 
                 setName(getName() + " : executing " + executable.toString());
                 Authentication auth = workUnit.context.item.authenticate();
-                LOGGER.log(FINE, "{0} is now executing {1} as {2}", new Object[] {getName(), executable, auth});
+                LOGGER.log(FINEST, "{0} is now executing {1} as {2}", new Object[] {getName(), executable, auth});
                 if (LOGGER.isLoggable(FINE) && auth.equals(ACL.SYSTEM)) { // i.e., unspecified
                     if (QueueItemAuthenticatorDescriptor.all().isEmpty()) {
                         LOGGER.fine("no QueueItemAuthenticator implementations installed");

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -1589,7 +1589,7 @@ public class Queue extends ResourceController implements Saveable {
                 if (causeOfBlockage != null) {
                     p.leave(this);
                     new BlockedItem(p, causeOfBlockage).enter(this);
-                    LOGGER.log(Level.FINE, "Catching that {0} is blocked in the last minute", p);
+                    LOGGER.log(Level.FINEST, "Catching that {0} is blocked in the last minute", p);
                     // JENKINS-28926 we have moved an unblocked task into the blocked state, update snapshot
                     // so that other buildables which might have been blocked by this can see the state change
                     updateSnapshot();

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1630,7 +1630,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
             if (tmp.exists()) {
                 tmp.deleteOnExit();
             }
-            LOGGER.log(FINE, "{0}: {1} successfully deleted", new Object[] {this, rootDir});
+            LOGGER.log(FINEST, "{0}: {1} successfully deleted", new Object[] {this, rootDir});
             removeRunFromParent();
         }
     }
@@ -1852,7 +1852,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
 
                     setResult(job.run(listener));
 
-                    LOGGER.log(INFO, "{0} main build action completed: {1}", new Object[] {this, result});
+                    LOGGER.log(FINEST, "{0} main build action completed: {1}", new Object[] {this, result});
                     CheckPoint.MAIN_COMPLETED.report();
                 } catch (ThreadDeath t) {
                     throw t;
@@ -1891,7 +1891,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
                 // will now see this build as completed.
                 // things like triggering other builds requires this as pre-condition.
                 // see issue #980.
-                LOGGER.log(FINER, "moving into POST_PRODUCTION on {0}", this);
+                LOGGER.log(FINEST, "moving into POST_PRODUCTION on {0}", this);
                 state = State.POST_PRODUCTION;
 
                 if (listener != null) {

--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -434,7 +434,7 @@ public abstract class Slave extends Node implements Serializable {
             if(res==null) {
                 throw new FileNotFoundException(name); // giving up
             } else {
-                LOGGER.log(Level.FINE, "found {0}", res);
+                LOGGER.log(Level.FINEST, "found {0}", res);
             }
             return res;
         }

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1177,7 +1177,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
                 File dst = job.getDestination();
                 File tmp = new File(dst.getPath()+".tmp");
 
-                LOGGER.info("Downloading "+job.getName());
+                LOGGER.finest("Downloading "+job.getName());
                 Thread t = Thread.currentThread();
                 String oldName = t.getName();
                 t.setName(oldName + ": " + src);

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -209,7 +209,7 @@ public class UpdateSite {
             }
         }
 
-        LOGGER.info("Obtained the latest update center data file for UpdateSource " + id);
+        LOGGER.finest("Obtained the latest update center data file for UpdateSource " + id);
         retryWindow = 0;
         getDataFile().write(json);
         data = new Data(o);
@@ -1361,7 +1361,7 @@ public class UpdateSite {
             for (Plugin dep : getNeededDependencies()) {
                 UpdateCenter.InstallationJob job = uc.getJob(dep);
                 if (job == null || job.status instanceof UpdateCenter.DownloadJob.Failure) {
-                    LOGGER.log(Level.INFO, "Adding dependent install of " + dep.name + " for plugin " + name);
+                    LOGGER.log(Level.FINEST, "Adding dependent install of " + dep.name + " for plugin " + name);
                     dep.deploy(dynamicLoad, /* UpdateCenterPluginInstallTest.test_installKnownPlugins specifically asks that these not be correlated */ null, batch);
                 } else {
                     LOGGER.log(Level.FINE, "Dependent install of {0} for plugin {1} already added, skipping", new Object[] {dep.name, name});

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -386,7 +386,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
 
         try {
             UserDetails userDetails = userDetailsService.loadUserByUsername(id);
-            LOGGER.log(Level.FINE, "Impersonation of the user {0} was a success", id);
+            LOGGER.log(Level.FINEST, "Impersonation of the user {0} was a success", id);
             return userDetails;
         } catch (UserMayOrMayNotExistException e) {
             LOGGER.log(Level.FINE, "The user {0} may or may not exist in the SecurityRealm, so we provide minimum access", id);

--- a/core/src/main/java/hudson/search/Search.java
+++ b/core/src/main/java/hudson/search/Search.java
@@ -370,7 +370,7 @@ public class Search implements StaplerProxy {
 
         List<SearchItem> items = new ArrayList<>(); // items found in 1 step
 
-        LOGGER.log(Level.FINE, "tokens={0}", tokens);
+        LOGGER.log(Level.FINEST, "tokens={0}", tokens);
         
         // first token
         int w=1;    // width of token
@@ -379,7 +379,7 @@ public class Search implements StaplerProxy {
             m.find(index,token,items);
             for (SearchItem si : items) {
                 paths[w].add(SuggestedItem.build(searchContext ,si));
-                LOGGER.log(Level.FINE, "found search item: {0}", si.getSearchName());
+                LOGGER.log(Level.FINEST, "found search item: {0}", si.getSearchName());
             }
             w++;
         }

--- a/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
+++ b/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
@@ -98,7 +98,7 @@ public class GlobalSecurityConfiguration extends ManagementLink implements Descr
         BulkChange bc = new BulkChange(Jenkins.get());
         try{
             boolean result = configure(req, req.getSubmittedForm());
-            LOGGER.log(Level.FINE, "security saved: "+result);
+            LOGGER.log(Level.FINEST, "security saved: "+result);
             Jenkins.get().save();
             FormApply.success(req.getContextPath()+"/manage").generateResponse(req, rsp, null);
         } finally {

--- a/core/src/main/java/hudson/slaves/ChannelPinger.java
+++ b/core/src/main/java/hudson/slaves/ChannelPinger.java
@@ -183,7 +183,7 @@ public class ChannelPinger extends ComputerListener {
     @VisibleForTesting
     @Restricted(NoExternalUse.class)
     public static void setUpPingForChannel(final Channel channel, final SlaveComputer computer, int timeoutSeconds, int intervalSeconds, final boolean analysis) {
-        LOGGER.log(Level.FINE, "setting up ping on {0} with a {1} seconds interval and {2} seconds timeout", new Object[] {channel.getName(), intervalSeconds, timeoutSeconds});
+        LOGGER.log(Level.FINEST, "setting up ping on {0} with a {1} seconds interval and {2} seconds timeout", new Object[] {channel.getName(), intervalSeconds, timeoutSeconds});
         final AtomicBoolean isInClosed = new AtomicBoolean(false);
         final PingThread t = new PingThread(channel, TimeUnit.SECONDS.toMillis(timeoutSeconds), TimeUnit.SECONDS.toMillis(intervalSeconds)) {
             @Override

--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -190,7 +190,7 @@ public class NodeProvisioner {
                 }, delay, TimeUnit.MILLISECONDS);
             }
         } else {
-            LOGGER.fine(() -> "ignoring suggested review for " + label);
+            LOGGER.finer(() -> "ignoring suggested review for " + label);
         }
     }
 

--- a/core/src/main/java/hudson/tasks/LogRotator.java
+++ b/core/src/main/java/hudson/tasks/LogRotator.java
@@ -26,6 +26,7 @@ package hudson.tasks;
 
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINER;
+import static java.util.logging.Level.FINEST;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -158,7 +159,7 @@ public class LogRotator extends BuildDiscarder {
                 if (shouldKeepRun(r, lsb, lstb)) {
                     continue;
                 }
-                LOGGER.log(FINE, "{0} is to be removed", r);
+                LOGGER.log(FINEST, "{0} is to be removed", r);
                 try { r.delete(); }
                 catch (IOException ex) { exceptionMap.put(r, ex); }
             }
@@ -187,7 +188,7 @@ public class LogRotator extends BuildDiscarder {
                 if (shouldKeepRun(r, lsb, lstb)) {
                     continue;
                 }
-                LOGGER.log(FINE, "{0} is to be purged of artifacts", r);
+                LOGGER.log(FINEST, "{0} is to be purged of artifacts", r);
                 try { r.deleteArtifacts(); }
                 catch (IOException ex) { exceptionMap.put(r, ex); }
             }

--- a/core/src/main/java/hudson/triggers/Trigger.java
+++ b/core/src/main/java/hudson/triggers/Trigger.java
@@ -270,7 +270,7 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
             for (Trigger t : p.getTriggers().values()) {
                 if (!(t instanceof SCMTrigger && scmd.synchronousPolling)) {
                     if (t !=null && t.spec != null && t.tabs != null) {
-                        LOGGER.log(Level.FINE, "cron checking {0} with spec ‘{1}’", new Object[]{p, t.spec.trim()});
+                        LOGGER.log(Level.FINEST, "cron checking {0} with spec ‘{1}’", new Object[]{p, t.spec.trim()});
 
                         if (t.tabs.check(cal)) {
                             LOGGER.log(Level.CONFIG, "cron triggered {0}", p);
@@ -291,7 +291,7 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
                                 LOGGER.log(Level.WARNING, t.getClass().getName() + ".run() failed for " + p, e);
                             }
                         } else {
-                            LOGGER.log(Level.FINER, "did not trigger {0}", p);
+                            LOGGER.log(Level.FINEST, "did not trigger {0}", p);
                         }
                     } else {
                         LOGGER.log(Level.WARNING, "The job {0} has a syntactically incorrect config and is missing the cron spec for a trigger", p.getFullName());

--- a/core/src/main/java/jenkins/install/InstallUtil.java
+++ b/core/src/main/java/jenkins/install/InstallUtil.java
@@ -316,7 +316,7 @@ public class InstallUtil {
 		installingPluginsFile.delete();
 		return;
 	}
-	LOGGER.fine("Writing install state to: " + installingPluginsFile.getAbsolutePath());
+	LOGGER.finest("Writing install state to: " + installingPluginsFile.getAbsolutePath());
 	Map<String,String> statuses = new HashMap<>();
 	for(UpdateCenterJob j : installingPlugins) {
 		if(j instanceof InstallationJob && j.getCorrelationId() != null) { // only include install jobs with a correlation id (directly selected)

--- a/core/src/main/java/jenkins/install/UpgradeWizard.java
+++ b/core/src/main/java/jenkins/install/UpgradeWizard.java
@@ -1,6 +1,6 @@
 package jenkins.install;
 
-import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.FINEST;
 
 import java.io.File;
 import java.io.IOException;
@@ -162,7 +162,7 @@ public class UpgradeWizard extends InstallState {
         File f = SetupWizard.getUpdateStateFile();
         FileUtils.touch(f);
         f.setLastModified(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1));
-        LOGGER.log(FINE, "Snoozed the upgrade wizard notice");
+        LOGGER.log(FINEST, "Snoozed the upgrade wizard notice");
         return HttpResponses.redirectToContextRoot();
     }
     

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3308,10 +3308,10 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             return;
         }
         if (currentMilestone == InitMilestone.COMPLETED) {
-            LOGGER.log(FINE, "setting version {0} to {1}", new Object[] {version, VERSION});
+            LOGGER.log(FINEST, "setting version {0} to {1}", new Object[] {version, VERSION});
             version = VERSION;
         } else {
-            LOGGER.log(FINE, "refusing to set version {0} to {1} during {2}", new Object[] {version, VERSION, currentMilestone});
+            LOGGER.log(FINEST, "refusing to set version {0} to {1} during {2}", new Object[] {version, VERSION, currentMilestone});
         }
 
         getConfigFile().write(this);

--- a/core/src/main/java/jenkins/model/PeepholePermalink.java
+++ b/core/src/main/java/jenkins/model/PeepholePermalink.java
@@ -160,7 +160,7 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
             } catch (IOException x) {
                 LOGGER.log(Level.WARNING, "failed to read " + storage, x);
             }
-            LOGGER.fine(() -> "loading from " + storage + ": " + cache);
+            LOGGER.finer(() -> "loading from " + storage + ": " + cache);
         }
         return cache;
     }
@@ -178,7 +178,7 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
         synchronized (cache) {
             cache.put(getId(), b == null ? RESOLVES_TO_NONE : b.getNumber());
             File storage = storageFor(buildDir);
-            LOGGER.fine(() -> "saving to " + storage + ": " + cache);
+            LOGGER.finest(() -> "saving to " + storage + ": " + cache);
             try {
                 AtomicFileWriter cw = new AtomicFileWriter(storage);
                 try {

--- a/core/src/main/java/jenkins/model/RunIdMigrator.java
+++ b/core/src/main/java/jenkins/model/RunIdMigrator.java
@@ -206,9 +206,9 @@ public final class RunIdMigrator {
             }
             try {
                 if (Util.isSymlink(kid)) {
-                    LOGGER.log(FINE, "deleting build number symlink {0} → {1}", new Object[] {name, Util.resolveSymlink(kid)});
+                    LOGGER.log(FINEST, "deleting build number symlink {0} → {1}", new Object[] {name, Util.resolveSymlink(kid)});
                 } else if (kid.isDirectory()) {
-                    LOGGER.log(FINE, "ignoring build directory {0}", name);
+                    LOGGER.log(FINEST, "ignoring build directory {0}", name);
                     continue;
                 } else {
                     LOGGER.log(WARNING, "need to delete anomalous file entry {0}", name);
@@ -226,7 +226,7 @@ public final class RunIdMigrator {
                 String name = kid.getName();
                 try {
                     Integer.parseInt(name);
-                    LOGGER.log(FINE, "skipping new build dir {0}", name);
+                    LOGGER.log(FINEST, "skipping new build dir {0}", name);
                     continue;
                 } catch (NumberFormatException x) {
                     // OK, next…
@@ -261,7 +261,7 @@ public final class RunIdMigrator {
                 File newKid = new File(dir, Integer.toString(number));
                 move(kid, newKid);
                 FileUtils.writeStringToFile(new File(newKid, "build.xml"), xml, Charsets.UTF_8);
-                LOGGER.log(FINE, "fully processed {0} → {1}", new Object[] {name, number});
+                LOGGER.log(FINEST, "fully processed {0} → {1}", new Object[] {name, number});
                 idToNumber.put(name, number);
             } catch (Exception x) {
                 LOGGER.log(WARNING, "failed to process " + kid, x);

--- a/core/src/main/java/jenkins/security/BasicHeaderRealPasswordAuthenticator.java
+++ b/core/src/main/java/jenkins/security/BasicHeaderRealPasswordAuthenticator.java
@@ -55,7 +55,7 @@ public class BasicHeaderRealPasswordAuthenticator extends BasicHeaderAuthenticat
         try {
             Authentication a = Jenkins.get().getSecurityRealm().getSecurityComponents().manager.authenticate(authRequest);
             // Authentication success
-            LOGGER.log(FINER, "Authentication success: {0}", a);
+            LOGGER.log(FINEST, "Authentication success: {0}", a);
             return a;
         } catch (AuthenticationException failed) {
             // Authentication failed

--- a/core/src/main/java/jenkins/security/CustomClassFilter.java
+++ b/core/src/main/java/jenkins/security/CustomClassFilter.java
@@ -169,7 +169,7 @@ public interface CustomClassFilter extends ExtensionPoint {
                     }
                 }
             }
-            Logger.getLogger(Contributed.class.getName()).log(Level.FINE, "plugin-defined entries: {0}", overrides);
+            Logger.getLogger(Contributed.class.getName()).log(Level.FINER, "plugin-defined entries: {0}", overrides);
         }
 
     }

--- a/core/src/main/java/jenkins/security/ExceptionTranslationFilter.java
+++ b/core/src/main/java/jenkins/security/ExceptionTranslationFilter.java
@@ -117,7 +117,7 @@ public class ExceptionTranslationFilter implements Filter, InitializingBean {
 		try {
 			chain.doFilter(request, response);
 
-			LOGGER.finer("Chain processed normally");
+			LOGGER.finest("Chain processed normally");
 		}
 		catch (AuthenticationException | AccessDeniedException ex) {
 			handleException(request, response, chain, ex);

--- a/core/src/main/java/jenkins/security/RekeySecretAdminMonitor.java
+++ b/core/src/main/java/jenkins/security/RekeySecretAdminMonitor.java
@@ -144,7 +144,7 @@ public class RekeySecretAdminMonitor extends AsynchronousAdministrativeMonitor {
             int count = rewriter.rewriteRecursive(Jenkins.get().getRootDir(), listener);
             log.printf("Completed re-keying %d files on %s\n",count,new Date());
             new RekeySecretAdminMonitor().done.on();
-            LOGGER.info("Secret re-keying completed");
+            LOGGER.finest("Secret re-keying completed");
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Fatal failure in re-keying secrets",e);
             Functions.printStackTrace(e, listener.error("Fatal failure in rewriting secrets"));

--- a/core/src/main/java/jenkins/security/ResourceDomainRootAction.java
+++ b/core/src/main/java/jenkins/security/ResourceDomainRootAction.java
@@ -175,7 +175,7 @@ public class ResourceDomainRootAction implements UnprotectedRootAction {
 
         // And finally, remove the 'restOfPath' suffix from the complete URL, as that's the path from Jenkins to the DBS.
         String dbsUrl = completeUrl.substring(0, completeUrl.length() - dbsFile.length());
-        LOGGER.fine(() -> "Determined DBS URL: " + dbsUrl + " from restOfUrl: " + completeUrl + " and restOfPath: " + dbsFile);
+        LOGGER.finest(() -> "Determined DBS URL: " + dbsUrl + " from restOfUrl: " + completeUrl + " and restOfPath: " + dbsFile);
 
         Authentication authentication = Jenkins.getAuthentication();
         String authenticationName = authentication == Jenkins.ANONYMOUS ? "" : authentication.getName();

--- a/core/src/main/java/jenkins/security/stapler/StaplerDispatchValidator.java
+++ b/core/src/main/java/jenkins/security/stapler/StaplerDispatchValidator.java
@@ -96,7 +96,7 @@ public class StaplerDispatchValidator implements DispatchValidator {
         if (status == null) {
             return null;
         }
-        LOGGER.fine(() -> "Request dispatch set status to " + status + " for URL " + req.getPathInfo());
+        LOGGER.finest(() -> "Request dispatch set status to " + status + " for URL " + req.getPathInfo());
         req.setAttribute(ATTRIBUTE_NAME, status);
         return status;
     }
@@ -127,7 +127,7 @@ public class StaplerDispatchValidator implements DispatchValidator {
             }
             return null;
         });
-        LOGGER.finer(() -> req.getRequestURI() + " -> " + status);
+        LOGGER.finest(() -> req.getRequestURI() + " -> " + status);
         return status;
     }
 
@@ -145,7 +145,7 @@ public class StaplerDispatchValidator implements DispatchValidator {
             }
             return cache.find(node.getClass()).isViewValid(viewName);
         });
-        LOGGER.finer(() -> "<" + req.getRequestURI() + ", " + viewName + ", " + node + "> -> " + status);
+        LOGGER.finest(() -> "<" + req.getRequestURI() + ", " + viewName + ", " + node + "> -> " + status);
         return status;
     }
 

--- a/core/src/main/java/jenkins/tools/GlobalToolConfiguration.java
+++ b/core/src/main/java/jenkins/tools/GlobalToolConfiguration.java
@@ -77,7 +77,7 @@ public class GlobalToolConfiguration extends ManagementLink {
     @POST
     public synchronized void doConfigure(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException, Descriptor.FormException {
         boolean result = configure(req, req.getSubmittedForm());
-        LOGGER.log(Level.FINE, "tools saved: "+result);
+        LOGGER.log(Level.FINEST, "tools saved: "+result);
         FormApply.success(req.getContextPath() + "/manage").generateResponse(req, rsp, null);
     }
 

--- a/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
+++ b/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
@@ -256,7 +256,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
                     }
                     List<Job> upstreams =
                             Items.fromNameList(downstream.getParent(), trigger.getUpstreamProjects(), Job.class);
-                    LOGGER.log(Level.FINE, "from {0} see upstreams {1}", new Object[]{downstream, upstreams});
+                    LOGGER.log(Level.FINER, "from {0} see upstreams {1}", new Object[]{downstream, upstreams});
                     for (Job upstream : upstreams) {
                         if (upstream instanceof AbstractProject && downstream instanceof AbstractProject) {
                             continue; // handled specially

--- a/core/src/main/java/jenkins/util/JSONSignatureValidator.java
+++ b/core/src/main/java/jenkins/util/JSONSignatureValidator.java
@@ -78,7 +78,7 @@ public class JSONSignatureValidator {
                         } catch (CertificateNotYetValidException e) {
                             warning = FormValidation.warning(e, String.format("Certificate %s is not yet valid in %s", cert.toString(), name));
                         }
-                        LOGGER.log(Level.FINE, "Add certificate found in json doc: \r\n\tsubjectDN: {0}\r\n\tissuer: {1}", new Object[]{c.getSubjectDN(), c.getIssuerDN()});
+                        LOGGER.log(Level.FINEST, "Add certificate found in json doc: \r\n\tsubjectDN: {0}\r\n\tissuer: {1}", new Object[]{c.getSubjectDN(), c.getIssuerDN()});
                         certs.add(c);
                     } catch (IllegalArgumentException ex) {
                         throw new IOException("Could not decode certificate", ex);
@@ -263,7 +263,7 @@ public class JSONSignatureValidator {
             }
             try {
                 TrustAnchor certificateAuthority = new TrustAnchor((X509Certificate) certificate, null);
-                LOGGER.log(Level.FINE, "Add Certificate Authority {0}: {1}",
+                LOGGER.log(Level.FINER, "Add Certificate Authority {0}: {1}",
                         new Object[]{cert, (certificateAuthority.getTrustedCert() == null ? null : certificateAuthority.getTrustedCert().getSubjectDN())});
                 anchors.add(certificateAuthority);
             } catch (IllegalArgumentException e) {
@@ -294,7 +294,7 @@ public class JSONSignatureValidator {
                 }
                 try {
                     TrustAnchor certificateAuthority = new TrustAnchor((X509Certificate) certificate, null);
-                    LOGGER.log(Level.FINE, "Add Certificate Authority {0}: {1}",
+                    LOGGER.log(Level.FINER, "Add Certificate Authority {0}: {1}",
                             new Object[]{cert, (certificateAuthority.getTrustedCert() == null ? null : certificateAuthority.getTrustedCert().getSubjectDN())});
                     anchors.add(certificateAuthority);
                 } catch (IllegalArgumentException e) {

--- a/core/src/main/java/jenkins/util/ProgressiveRendering.java
+++ b/core/src/main/java/jenkins/util/ProgressiveRendering.java
@@ -178,7 +178,7 @@ public abstract class ProgressiveRendering {
             }
         }
         List/*<AncestorImpl>*/ ancestors = currentRequest.ancestors;
-        LOG.log(Level.FINER, "mocking ancestors {0} using {1}", new Object[] {ancestors, getters});
+        LOG.log(Level.FINEST, "mocking ancestors {0} using {1}", new Object[] {ancestors, getters});
         TokenList tokens = currentRequest.tokens;
         return new RequestImpl(Stapler.getCurrent(), (HttpServletRequest) Proxy.newProxyInstance(ProgressiveRendering.class.getClassLoader(), new Class<?>[] {HttpServletRequest.class}, new InvocationHandler() {
             @Override public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {

--- a/core/src/main/java/jenkins/util/SystemProperties.java
+++ b/core/src/main/java/jenkins/util/SystemProperties.java
@@ -142,7 +142,7 @@ public class SystemProperties {
                 for (String key : ALLOW_ON_AGENT) {
                     snapshot.put(key, getString(key));
                 }
-                LOGGER.log(Level.FINE, "taking snapshot of {0}", snapshot);
+                LOGGER.log(Level.FINEST, "taking snapshot of {0}", snapshot);
             }
             @Override
             public Void call() throws RuntimeException {


### PR DESCRIPTION
We appreciate your previous feedback and it's very helpful. Here's a reissue of jenkinsci#4007 with a new version of our tool. It takes a long time, sorry for waiting. The tool made many fewer transformations, especially for the transformations from `INFO` to `FINEST`, however, there were a few that we removed that you did not agree with in the original PR. Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

Treat CONFIG, WARNING, and SEVERE levels as a category and not a traditional level, i.e., our tool ignores these log levels.
Never lower the logging level of logging statements within catch blocks.
Never lower the logging level of logging statements within if statements.
Never lower the logging level of logging statements containing certain (important) keywords.
Never raise the logging level of logging statements without particular keywords in their messages.
Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
The greatest number of commits from HEAD evaluated: 1000.
The head at the time of analysis was: 4f0436abb1ef55372152e13f4b6953f1f216d1ba

### Desired reviewers

@**daniel-beck